### PR TITLE
Update `:action Vim*` mappings

### DIFF
--- a/.ideavimrc
+++ b/.ideavimrc
@@ -24,15 +24,14 @@ nnoremap <space>oo :action MoveEditorToOppositeTabGroup<cr>
 
 # Windows (Tabs)
 nnoremap <space>wd :action CloseContent<cr>
-nnoremap <space>wj :action VimWindowDown<cr>
 nnoremap <space>ws :action SplitHorizontally<cr>
 nnoremap <space>wu :action Unsplit<cr>
 nnoremap <space>wv :action SplitVertically<cr>
-nnoremap <space>ww :action VimWindowNext<cr>
-nnoremap <space>wl :action VimWindowRight<cr>
-nnoremap <space>wh :action VimWindowLeft<cr>
-nnoremap <space>wk :action VimWindowUp<cr>
-nnoremap <space>wj :action VimWindowDown<cr>
+nnoremap <space>ww <C-w><C-w>
+nnoremap <space>wl <C-w>l
+nnoremap <space>wh <C-w>h
+nnoremap <space>wk <C-w>k
+nnoremap <space>wj <C-w>j
 
 # Comments
 nnoremap <space>cl :action CommentByLineComment<cr>
@@ -43,3 +42,4 @@ nnoremap <space>ri :action ShowIntentionActions<cr>
 
 # Types
 nnoremap <space>ti :action Scala.TypeInfo<cr>
+set ideajoin


### PR DESCRIPTION
Since 0.54 version of IdeaVim all the :action Vim mappings don't work anymore. Instead of mappings to :action, map keys to the vim <C-w> command. [Jetbrains issue for reference](https://youtrack.jetbrains.com/issue/VIM-1871#focus=streamItem-27-3864326.0-0)